### PR TITLE
Fixed Multi Enemy Death Bug

### DIFF
--- a/Assets/Enemies/EnemyAI.cs
+++ b/Assets/Enemies/EnemyAI.cs
@@ -165,7 +165,7 @@ public class EnemyAI : MonoBehaviour
         //Debug.Log("Searching is called");
     }
 
-    private void Death()
+    public void Death()
     {
         lastCalledTime = DateTime.Now;
         moveSpeed = 0f;
@@ -175,7 +175,7 @@ public class EnemyAI : MonoBehaviour
     }
     void OnDisable()
     {
-        Trap.OnEnemyDeath -= Death;
+    //    Trap.OnEnemyDeath -= Death;
 
     }
 }

--- a/Assets/Enemies/Trap.cs
+++ b/Assets/Enemies/Trap.cs
@@ -37,7 +37,10 @@ public class Trap : MonoBehaviour
 
             if (collider.gameObject.CompareTag("Enemy"))
             {
-                OnEnemyDeath?.Invoke();
+                //OnEnemyDeath?.Invoke();
+
+                //good fix
+                collider.gameObject.GetComponent<EnemyAI>().Death();
 
             }
 


### PR DESCRIPTION
Fixed bug that would kill all enemies instead of one that stepped on trap. Changed kill method from a broadcast to directly referencing death function of enemy triggering trap. Required change to public to function.